### PR TITLE
Corrected code that raise error after numpy update

### DIFF
--- a/pyFRF.py
+++ b/pyFRF.py
@@ -170,7 +170,7 @@ class FRF:
             raise Exception('wrong response window type given %s (can be %s)'
                             % (self.resp_window, _WINDOWS))
 
-        self.curr_meas = np.int(0)
+        self.curr_meas = int(0)
 
         if exc is not None and resp is not None:
             self.add_data(exc, resp)


### PR DESCRIPTION
When using the library, numpy raised an error relating to the deprecation of np.int. It suggests that the new correct way of doing this is using int() or any of the numpy integer functions (such as np.int32, np.int64, etc.). I propose using int() because, upon cursory testing of the function, I found it to solve the issue wile also being retrocompatible.